### PR TITLE
Fix bullet rendering inconsistencies

### DIFF
--- a/src/client_net.c
+++ b/src/client_net.c
@@ -164,11 +164,20 @@ int client_poll_messages(void) {
                     for (int i = 0; i < MAX_REMOTE_BULLETS; ++i) { if (!g_remote_bullets[i].active) { slot = i; break; } }
                 }
                 if (slot >= 0) {
+                    int wasActive = g_remote_bullets[slot].active;
                     g_remote_bullets[slot].active = active;
-                    // store last for smoothing
-                    g_remote_bullets[slot].lastWorldX = g_remote_bullets[slot].worldX;
-                    g_remote_bullets[slot].lastWorldY = g_remote_bullets[slot].worldY;
-                    g_remote_bullets[slot].lastPos = g_remote_bullets[slot].pos;
+                    // initialize smoothing baseline on first activation to avoid sliding
+                    if (active && !wasActive) {
+                        g_remote_bullets[slot].lastWorldX = wx;
+                        g_remote_bullets[slot].lastWorldY = wy;
+                        g_remote_bullets[slot].lastPos.x = x;
+                        g_remote_bullets[slot].lastPos.y = y;
+                    } else {
+                        // store last for smoothing
+                        g_remote_bullets[slot].lastWorldX = g_remote_bullets[slot].worldX;
+                        g_remote_bullets[slot].lastWorldY = g_remote_bullets[slot].worldY;
+                        g_remote_bullets[slot].lastPos = g_remote_bullets[slot].pos;
+                    }
                     g_remote_bullets[slot].worldX = wx;
                     g_remote_bullets[slot].worldY = wy;
                     g_remote_bullets[slot].pos.x = x;

--- a/src/game.c
+++ b/src/game.c
@@ -393,7 +393,7 @@ void game_draw(void) {
                                     if (by > ly) sy = ly + 1; else if (by < ly) sy = ly - 1;
                                     bx = sx; by = sy;
                                 }
-                            } else if (bticks >= 3 && bticks < 10) {
+                            } else if (bticks >= 4 && bticks < 15) {
                                 int sdx = (mdx > 0) ? 1 : (mdx < 0 ? -1 : 0);
                                 int sdy = (mdy > 0) ? 1 : (mdy < 0 ? -1 : 0);
                                 int ex = clamp(bx + sdx, 0, MAP_WIDTH - 1);


### PR DESCRIPTION
Fix bullet movement inconsistencies by adjusting extrapolation `bticks` conditions and initializing smoothing fields on activation.

The previous `bticks` condition for bullet extrapolation (`bticks >= 3 && bticks < 10`) overlapped with interpolation, causing `bticks == 3` to always interpolate, inconsistent with player movement. Additionally, new bullets would visually slide from the origin because `lastPos`, `lastWorldX`, and `lastWorldY` were uninitialized upon first activation.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf60d649-c362-42b3-8971-5f9ca5b635d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf60d649-c362-42b3-8971-5f9ca5b635d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

