### PR TITLE
Debug game startup issue in zsh

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -43,7 +43,7 @@ static void handleInput(void) {
 
 static void print_menu(void) {
     term_clear_screen();
-    printf("Dungeon\n\n1) Singleplayer\n2) Multiplayer\nSelect: ");
+    printf("Dungeon\n\n1) Singleplayer (S)\n2) Multiplayer (M)\nSelect [1/2/S/M]: ");
     fflush(stdout);
 }
 
@@ -63,7 +63,8 @@ int main(void) {
     print_menu();
     while (!mode) {
         int c = input_read_nonblocking();
-        if (c == '1') mode = 1; else if (c == '2') mode = 2;
+        if (c == '1' || c == 's' || c == 'S') mode = 1;
+        else if (c == '2' || c == 'm' || c == 'M') mode = 2;
         if (!mode) {
             // small sleep
 #ifdef _WIN32


### PR DESCRIPTION
Allow 'S'/'M' keys for SP/MP selection in the main menu to fix game startup issues in zsh on macOS.

Some macOS zsh setups can have timing quirks with raw mode and non-blocking reads, making number key input unreliable. Adding letter shortcuts makes the selection more robust.

---
<a href="https://cursor.com/background-agent?bcId=bc-b563c71d-c3b0-45ae-a15c-ab46e2669890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b563c71d-c3b0-45ae-a15c-ab46e2669890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

