### PR TITLE
Remove ineffective zsh game selection options

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -43,7 +43,7 @@ static void handleInput(void) {
 
 static void print_menu(void) {
     term_clear_screen();
-    printf("Dungeon\n\n1) Singleplayer (S)\n2) Multiplayer (M)\nSelect [1/2/S/M]: ");
+    printf("Dungeon\n\n1) Singleplayer\n2) Multiplayer\nSelect [1/2]: ");
     fflush(stdout);
 }
 
@@ -63,8 +63,8 @@ int main(void) {
     print_menu();
     while (!mode) {
         int c = input_read_nonblocking();
-        if (c == '1' || c == 's' || c == 'S') mode = 1;
-        else if (c == '2' || c == 'm' || c == 'M') mode = 2;
+        if (c == '1') mode = 1;
+        else if (c == '2') mode = 2;
         if (!mode) {
             // small sleep
 #ifdef _WIN32


### PR DESCRIPTION
Remove S/M menu selection options as they did not resolve the zsh map rendering issue.

The S/M options were an earlier attempt to address a truncated map rendering problem in zsh, but they proved ineffective. This PR reverts the menu selection to its prior state (1/2 only) to simplify the interface and eliminate an unhelpful feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-07210add-9841-4750-aa48-44d2f4118dc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07210add-9841-4750-aa48-44d2f4118dc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

